### PR TITLE
Add "enabled" accessor to gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Add 'enabled' configuration setting

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Add this line to your application's Gemfile:
 gem "chat_gpt_error_handler"
 ```
 
-Set your [OpenAI API Token](https://openai.com/product#made-for-developers) in an initializer:
+Set your [OpenAI API Token](https://openai.com/product#made-for-developers) and enable the gem in an initializer:
 
 ```ruby
 # config/initializers/chat_gpt_error_handler.rb
 ChatGptErrorHandler.openai_access_token = 'your_openai_access_token_here'
+ChatGptErrorHandler.enabled = true
 ```
 
 And you're off!

--- a/lib/chat_gpt_error_handler.rb
+++ b/lib/chat_gpt_error_handler.rb
@@ -2,8 +2,11 @@ require "chat_gpt_error_handler/version"
 require "chat_gpt_error_handler/engine"
 
 module ChatGptErrorHandler
-    mattr_accessor :openai_access_token
+    mattr_accessor :openai_access_token, :enabled
 
   # Default value for the openai_access_token, used when not explicitly set by the user
   @@openai_access_token = nil
+
+  # Default value to allow opting-in
+  @@enabled = false
 end

--- a/lib/chat_gpt_error_handler/error_handler.rb
+++ b/lib/chat_gpt_error_handler/error_handler.rb
@@ -5,8 +5,10 @@ module ChatGptErrorHandler
   class ErrorHandler
     def initialize(app)
       @app = app
-      OpenAI.configure do |config|
-        config.access_token = ChatGptErrorHandler.openai_access_token || ENV.fetch('OPENAI_ACCESS_TOKEN')
+      if ChatGptErrorHandler.enabled
+        OpenAI.configure do |config|
+          config.access_token = ChatGptErrorHandler.openai_access_token || ENV.fetch('OPENAI_ACCESS_TOKEN')
+        end
       end
     end
 
@@ -14,7 +16,7 @@ module ChatGptErrorHandler
       begin
         @app.call(env)
       rescue => error
-        send_to_gpt(error)
+        send_to_gpt(error) if ChatGptErrorHandler.enabled
         raise error
       end
     end

--- a/test/chat_gpt_error_handler_test.rb
+++ b/test/chat_gpt_error_handler_test.rb
@@ -4,4 +4,12 @@ class ChatGptErrorHandlerTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert ChatGptErrorHandler::VERSION
   end
+
+  test "you can enable the module" do
+    refute ChatGptErrorHandler.enabled
+
+    ChatGptErrorHandler.enabled = true
+
+    assert ChatGptErrorHandler.enabled
+  end
 end

--- a/test/lib/chat_gpt_error_handler/error_handler_test.rb
+++ b/test/lib/chat_gpt_error_handler/error_handler_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+module ChatGptErrorHandler
+  class MockApp
+    def call(env)
+    end
+  end
+
+  class ErrorHandlerTest < ActiveSupport::TestCase
+    test "ErrorHandler instantiates successfully by default" do
+      app = MockApp.new
+
+      assert_nothing_raised do
+        ChatGptErrorHandler::ErrorHandler.new(app)
+      end
+    end
+
+    test "if you enable ChatGptErrorHandler it needs, and sets, an access token" do
+      ChatGptErrorHandler.openai_access_token = 'acc3ss-t0k3n'
+      ChatGptErrorHandler.enabled = true
+
+      app = MockApp.new
+
+      ChatGptErrorHandler::ErrorHandler.new(app)
+
+      assert_equal OpenAI.configuration.access_token, 'acc3ss-t0k3n'
+    end
+
+    test "if you enable ChatGptErrorHandler you also need an access token" do
+      ChatGptErrorHandler.enabled = true
+
+      app = MockApp.new
+
+      exception = assert_raises KeyError do
+        ChatGptErrorHandler::ErrorHandler.new(app)
+      end
+      assert_equal 'key not found: "OPENAI_ACCESS_TOKEN"', exception.message
+    end
+  end
+end


### PR DESCRIPTION
Solves issue: https://github.com/Schwad/chat_gpt_error_handler/issues/2

This PR proposes adding an `enabled` accessor to the gem so that it can be opted into after the gem is added to an app. 

It's `false` by default but once someone has set enabled to true, they'll need to have set an access token in their ENV or the initializer. The `KeyError` here happens currently if someone adds this gem to their app and boots it without an `OPENAI_ACCESS_TOKEN` 

```
ChatGptErrorHandler.openai_access_token = ENV.fetch('OPENAI_ACCESS_TOKEN', nil)
ChatGptErrorHandler.enabled = ENV.fetch('CHAT_GPT_ERROR_HANDLER', false)
```

Added some small tests...not totally sure about their implementation 😅 so feedback welcome